### PR TITLE
[fixed #160947853] ステップ12: バリデーションを設定しよう

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,4 @@
 class Task < ApplicationRecord
-  validates :title, presence: true
+  validates :title, presence: true, length: { maximum: 30 }
   validates :description, length: { maximum: 100 }
 end

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,12 @@
+<% if object.errors.any? %>
+  <div id="error_explanation">
+    <div class="alert alert-danger">
+      <%= object.errors.count %>件のエラーがあります。
+    </div>
+    <ul>
+      <% object.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -1,4 +1,6 @@
 <%= form_with(model: @task, local: true) do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
+  
   <%= f.label :title %>
   <%= f.text_field :title %>
   <%= f.label :description %>

--- a/db/migrate/20181005083154_change_column_to_task.rb
+++ b/db/migrate/20181005083154_change_column_to_task.rb
@@ -1,0 +1,5 @@
+class ChangeColumnToTask < ActiveRecord::Migration[5.2]
+  def change
+    change_column :tasks, :title, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_01_084246) do
+ActiveRecord::Schema.define(version: 2018_10_05_083154) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "tasks", force: :cascade do |t|
-    t.string "title"
+    t.string "title", null: false
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
- タスクタイトルの文字数を最大30文字に制限した
- タスクタイトルにnot null制約を付与した
- ビューにエラーメッセージを追加した